### PR TITLE
Fix error thrown when resizing an image

### DIFF
--- a/servicebusthumbnail/function.json
+++ b/servicebusthumbnail/function.json
@@ -1,7 +1,7 @@
 {
   "bindings": [
     {
-      "name": "mySbMsg",
+      "name": "message",
       "type": "serviceBusTrigger",
       "direction": "in",
       "queueName": "thumbnailqueue",
@@ -10,17 +10,17 @@
     {
       "type": "cosmosDB",
       "direction": "in",
-      "name": "inputimage",
+      "name": "document",
       "databaseName": "azure101",
       "collectionName": "images",
       "connectionStringSetting": "victoricosmosdb_DOCUMENTDB",
       "id": "{id}",
-      "PartitionKey": "{id}"
+      "partitionKey": "{id}"
     },
     {
       "type": "blob",
       "direction": "in",
-      "name": "inputimageblob",
+      "name": "image",
       "path": "images/{id}",
       "dataType": "binary",
       "connection": "victorimagestore_CONNECTION_STRING"

--- a/servicebusthumbnail/index.ts
+++ b/servicebusthumbnail/index.ts
@@ -1,30 +1,33 @@
 import { AzureFunction, Context, HttpRequest } from "@azure/functions";
 import resizeImg from "resize-img"
 
-interface inputDocument {
+interface Message {
     id: string,
     uri: string,
-    thumbnail: string
 }
+
+interface Document extends Message {
+  thumbnail?: string
+}
+
 const serviceBusQueueTrigger: AzureFunction = async function (
   context: Context,
-  inputimage: inputDocument
+  message: Message,
+  document: Document,
+  image: Buffer
 ): Promise<void> {
   context.log.warn("AM I ALIVE?")
+
   const account = "victorimagestore";
-  const resizedImage = await resizeImg(context.bindings.inputimageblob, {
+  const resizedImage = await resizeImg(image, {
     width: 128, 
     height: 128
   })
 
-  const POST_BODY = {
-    ...inputimage,
-    thumbnail: `https://${account}.blob.core.windows.net/thumbnail/${inputimage.id}`,
-  };
-
-  context.bindings.outputimage = POST_BODY
-  context.bindings.outputimageblob = resizedImage
+  document.thumbnail = `https://${account}.blob.core.windows.net/thumbnail/${message.id}`
   
+  context.bindings.outputimage = document
+  context.bindings.outputimageblob = resizedImage
 };
 
 export default serviceBusQueueTrigger;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "outDir": "dist",
     "rootDir": ".",
     "sourceMap": true,
-    "strict": false
+    "strict": false,
+    "esModuleInterop": true
   }
 }


### PR DESCRIPTION
The error was thrown due to missing `tsconfig.json`configuration, see my first commit. The second commit is just a refactor to clean up the names of the input bindings.